### PR TITLE
Fix usage of ⌘ key in tooltips on non Apple platforms

### DIFF
--- a/src/osMacros.h
+++ b/src/osMacros.h
@@ -1,0 +1,15 @@
+#ifndef _OS_MACROS
+#define _OS_MACROS
+
+#ifdef __APPLE__
+//On macOS, special functions are behind the modifier called "CMD"
+#define FV_USE_CMD_KEY 1
+#define FV_MOD_C       "⌘"
+#else
+
+//On other platforms, special functions are behind the modifier called "Control"
+#define FV_USE_CMD_KEY 0
+#define FV_MOD_C       "Ctrl"
+#endif
+
+#endif //_OS_MACROS

--- a/src/window/windowParamView.cpp
+++ b/src/window/windowParamView.cpp
@@ -1,6 +1,7 @@
 #include "preferences.h"
 #include "window.h"
 #include "windowUtils.h"
+#include "osMacros.h"
 #include <imgui.h>
 
 //--- Main Parameter View Routine ---//
@@ -120,7 +121,7 @@ void mainWindow::paramView() {
 
                     ImGui::Text("Base Color:");
                     paramChange |= ImGui::ColorEdit3("##BC", (float*)activeImage()->imgParam.baseColor, ImGuiColorEditFlags_Float | ImGuiColorEditFlags_PickerHueWheel);
-                    ImGui::SetItemTooltip("Hold ⌘ + shift, click and drag an area in the image\nto sample the base color.");
+                    ImGui::SetItemTooltip("Hold " FV_MOD_C " + shift, click and drag an area in the image\nto sample the base color.");
                     ImGui::SameLine();
                     if(ImGui::Button("Reset##a1")){activeImage()->imgParam.rstBC(); paramChange |= true;}
                     ImGui::Text("Analysis Bias");
@@ -168,19 +169,19 @@ void mainWindow::paramView() {
                     setTempColor(activeImage()->imgParam.temp);
                     paramChange |= ImGui::SliderFloat("##TMP", &activeImage()->imgParam.temp, -1.0f, 1.0f);
                     ImGui::PopStyleColor(3);
-                    ImGui::SetItemTooltip("Adjust the color temperature of the image.\n⌘ + Click to edit the value manually");
+                    ImGui::SetItemTooltip("Adjust the color temperature of the image.\n" FV_MOD_C " + Click to edit the value manually");
                     ImGui::SameLine();
                     if (ImGui::Button("Reset##03")){activeImage()->imgParam.rstTmp(); paramChange = true;}
                     ImGui::Text("Tint");
                     setTintColor(activeImage()->imgParam.tint);
                     paramChange |= ImGui::SliderFloat("##TNT", &activeImage()->imgParam.tint, -1.0f, 1.0f);
                     ImGui::PopStyleColor(3);
-                    ImGui::SetItemTooltip("Adjust the tint of the image.\n⌘ + Click to edit the value manually");
+                    ImGui::SetItemTooltip("Adjust the tint of the image.\n" FV_MOD_C " + Click to edit the value manually");
                     ImGui::SameLine();
                     if (ImGui::Button("Reset##04")){activeImage()->imgParam.rstTnt(); paramChange = true;}
                     ImGui::Text("Saturation");
                     paramChange |= ImGui::SliderFloat("##SAT", &activeImage()->imgParam.saturation, -1.0f, 1.0f);
-                    ImGui::SetItemTooltip("Adjust the saturation of the image.\n⌘ + Click to edit the value manually");
+                    ImGui::SetItemTooltip("Adjust the saturation of the image.\n" FV_MOD_C" + Click to edit the value manually");
                     ImGui::SameLine();
                     if (ImGui::Button("Reset##04s")){activeImage()->imgParam.rstSat(); paramChange = true;}
                     ImGui::Text("Black Point");


### PR DESCRIPTION
This patch introduce a new header called osMacros.h.

This header is intended to contain build-time information about the operating system detected by the compiler, and provide whatever may be platform dependant.

For now it only has the switch for the name of the keyboard key you use for some operations, which is Cmd (⌘) on Mac and Ctrl on all the other computer in the known universe 😜