### PR TITLE
Fix uninitialised thread count when preference file does not exist

### DIFF
--- a/conan-recipes/opencolorio/conanfile.py
+++ b/conan-recipes/opencolorio/conanfile.py
@@ -53,9 +53,8 @@ class OpenColorIOConan(ConanFile):
 
     def requirements(self):
         self.requires("expat/[>=2.6.2 <3]")
-        if self.settings.os == "Windows":
-            self.requires("glew/[>=2.1.0]")
-            self.requires("freeglut/[>=3.2.2]")
+        self.requires("glew/[>=2.1.0]")
+        self.requires("freeglut/[>=3.2.2]")
         if Version(self.version) < "2.2.0":
             self.requires("openexr/2.5.7")
         else:
@@ -146,20 +145,20 @@ class OpenColorIOConan(ConanFile):
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
 
+        # glew/glut
+        glew_dep = self.dependencies["glew"]
+        freeglut_dep = self.dependencies["freeglut"]
+
         if self.settings.os == "Windows":
-            # glew/glut
-            glew_dep = self.dependencies["glew"]
-            freeglut_dep = self.dependencies["freeglut"]
-
             # Convert Windows paths to use forward slashes for CMake
-            glew_root = glew_dep.package_folder.replace("\\", "/")
-            glut_root = freeglut_dep.package_folder.replace("\\", "/")
+            glew_dep = glew_dep.package_folder.replace("\\", "/")
+            freeglut_dep = freeglut_dep.package_folder.replace("\\", "/")
 
-            tc.variables["GLEW_ROOT"] = glew_root
-            tc.variables["GLUT_ROOT"] = glut_root
+            tc.variables["GLEW_ROOT"] = glew_dep
+            tc.variables["GLUT_ROOT"] = freeglut_dep
 
-            # Set specific GLEW variables that OpenColorIO expects
-            tc.variables["GLEW_INCLUDE_DIRS"] = f"{glew_root}/include"
+        # Set specific GLEW variables that OpenColorIO expects
+        tc.variables["GLEW_INCLUDE_DIRS"] = f"{glew_dep}/include"
 
         tc.generate()
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,15 @@ int main(void)
 
     // Setup Threadpool
     unsigned int numThreads = appPrefs.prefs.maxSimExports;
-    numThreads = numThreads < 1 ? 2 : numThreads;
+
+    if (numThreads == 0 || numThreads > 4096) {
+        // It's unlikely anyone has set this high, so cap it back to a sensible number
+        // This should also catch the case where std::thread::hardware_concurrency returns
+        // bad values too
+        LOG_WARN("Threads set to {}, resetting to 2", numThreads);
+        numThreads = 2;
+    }
+
     LOG_INFO("Starting thread pool with {} threads", numThreads);
     tPool = new ThreadPool(numThreads);
 

--- a/src/preferences.cpp
+++ b/src/preferences.cpp
@@ -19,8 +19,11 @@ userPreferences appPrefs;
 void userPreferences::loadFromFile() {
     try {
         std::ifstream f(getPrefFile().c_str());
-        if (!f)
+        if (!f) {
+            LOG_INFO("No preferences file found, or file handle invalid.");
             return;
+        }
+
         nlohmann::json prefObj;
         prefObj = nlohmann::json::parse(f);
         if (prefObj.contains("Preferences")) {

--- a/src/preferences.h
+++ b/src/preferences.h
@@ -38,7 +38,7 @@ struct preferenceSet {
     int debayerMode = 10;
 
     // Max simultaneous exports
-    int maxSimExports = -1;
+    int maxSimExports = 0;
 
     // OCIO
     std::string ocioPath;


### PR DESCRIPTION
This PR fixes two problems I ran into locally, with these changes I can now build and start Filmvert locally:

Fixes: #35   
Get GLEW/GLUT working with `OpenColorIO` so the package can be built on Linux by moving the requirements to be global instead of Windows only

Fixes: #41 
Handle cases where a preferences file doesn't exist and add various checks, guards and logging. This should resolve the problem the other person was seeing too. In my logs I can see it was set to the new default `0` confirming it must have underflowed after casting `-1` to an unsigned int

I've added more detail to each commit and I'm happy to change/tweak anything